### PR TITLE
Fix wrapper when rebase.autostash is enabled

### DIFF
--- a/git-wrapper
+++ b/git-wrapper
@@ -5,6 +5,9 @@
 # Use this like |path/to/git-wrapper.sh rebase mozcentral|.
 
 set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+
 function cleanup {
     if [ -n R_CONFIGS_SET ]; then
         echo "wrapper> Cleaning up configs" >&2
@@ -14,10 +17,10 @@ function cleanup {
     fi
 
     if [ -n R_GITATTRIBUTES ]; then
-        echo "wrapper> Cleaning up .gitattributes" >&2
-        rm .gitattributes
-        if [ -f .gitattributes.bak ]; then
-            mv .gitattributes.bak .gitattributes
+        echo "wrapper> Cleaning up $ROOT/.git/info/attributes" >&2
+        rm "$ROOT/.git/info/attributes"
+        if [ -f "$ROOT/.git/info/attributes".bak ]; then
+            mv "$ROOT/.git/info/attributes".bak "$ROOT/.git/info/attributes"
         fi
     fi
 }
@@ -34,12 +37,12 @@ git config merge.clang-format.recursive "binary"
 R_CONFIGS_SET=1
 
 # Write out gitattributes
-if [ -f .gitattributes ]; then
-    cp .gitattributes .gitattributes.bak
+if [ -f "$ROOT/.git/info/attributes" ]; then
+    cp "$ROOT/.git/info/attributes" "$ROOT/.git/info/attributes.bak"
 fi
 
-echo "wrapper> Adding .gitattributes" >&2
-cat >> .gitattributes <<EOF
+echo "wrapper> Adding $ROOT/.git/info/attributes" >&2
+cat >> "$ROOT/.git/info/attributes" <<EOF
 *.cpp merge=clang-format
 *.h   merge=clang-format
 *.mm  merge=clang-format

--- a/git-wrapper
+++ b/git-wrapper
@@ -9,14 +9,14 @@ set -e
 ROOT="$(git rev-parse --show-toplevel)"
 
 function cleanup {
-    if [ -n R_CONFIGS_SET ]; then
+    if [ -n "$R_CONFIGS_SET" ]; then
         echo "wrapper> Cleaning up configs" >&2
         git config --unset merge.clang-format.name
         git config --unset merge.clang-format.driver
         git config --unset merge.clang-format.recursive
     fi
 
-    if [ -n R_GITATTRIBUTES ]; then
+    if [ -n "$R_GITATTRIBUTES" ]; then
         echo "wrapper> Cleaning up $ROOT/.git/info/attributes" >&2
         rm "$ROOT/.git/info/attributes"
         if [ -f "$ROOT/.git/info/attributes".bak ]; then
@@ -27,7 +27,7 @@ function cleanup {
 trap cleanup EXIT
 
 SOURCE="${BASH_SOURCE[0]}"
-MERGE_DRIVER="$(dirname $SOURCE)/clang-format-merge"
+MERGE_DRIVER="$(dirname "$SOURCE")/clang-format-merge"
 
 # Updating git config to install merge driver
 echo "wrapper> Setting Configs" >&2


### PR DESCRIPTION
Use `.git/info/attributes` rather than `.gitattributes` file in git-wrapper.

Changes to `.gitattributes` get undone when rebasing if you have `rebase.autostash` enabled in your git config. This also matches the manual installation suggested in the README.

Fixes https://github.com/emilio/clang-format-merge/issues/4

Also added some fixes suggested by [shellcheck](https://www.shellcheck.net/).